### PR TITLE
[Update] change Experience components to responsive web (#28)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -97,7 +97,7 @@ function App() {
         <Item title="2" />
         <Item title="3" />
       </Carousel>
-      
+
       <CardWrap>
         <Card width="20vw" height="20vw" hover="down" redirectURL="/1">
           This is Card component

--- a/app/src/lib/components/Experience/Experience.tsx
+++ b/app/src/lib/components/Experience/Experience.tsx
@@ -39,7 +39,7 @@ export default Experience;
 
 Experience.defaultProps = {
   title: 'Experience',
-  theme: 'vertical',
+  theme: 'basic',
   historyList: [
     {
       startDate: 'startDate',

--- a/app/src/lib/components/Experience/Experience.tsx
+++ b/app/src/lib/components/Experience/Experience.tsx
@@ -39,7 +39,7 @@ export default Experience;
 
 Experience.defaultProps = {
   title: 'Experience',
-  theme: 'basic',
+  theme: 'vertical',
   historyList: [
     {
       startDate: 'startDate',

--- a/app/src/lib/components/Experience/Experience.tsx
+++ b/app/src/lib/components/Experience/Experience.tsx
@@ -12,19 +12,23 @@ interface Props {
   title?: string;
   textAlign?: string;
   background?: string;
-  theme?: 'basic' | 'box';
+  theme?: 'basic' | 'box' | 'vertical';
+  verticalOption?: {
+    titleColor?: string;
+    shape?: 'square' | 'round-square';
+  };
 }
 
 const Experience = (props: Props) => {
-  const { historyList, title, textAlign, background, theme } = props;
+  const { historyList, title, textAlign, background, theme, verticalOption } = props;
 
   return (
     <Wrap textAlign={textAlign} background={background}>
       <div className="title">{title}</div>
       <hr />
-      <ChildWrap>
+      <ChildWrap theme={theme}>
         {historyList?.map((elements, idx) => (
-          <History key={idx} {...elements} theme={theme} />
+          <History {...verticalOption} key={idx} {...elements} theme={theme} />
         ))}
       </ChildWrap>
     </Wrap>
@@ -35,8 +39,25 @@ export default Experience;
 
 Experience.defaultProps = {
   title: 'Experience',
-  theme: 'box',
+  theme: 'vertical',
   historyList: [
+    {
+      startDate: 'startDate',
+      endDate: 'endDate',
+      title: 'this is title',
+      des: 'This prop name is des.\nWrite down the additional explanation you want here.\nYou can break the line to backslash-n.',
+    },
+    {
+      startDate: 'startDate',
+      endDate: 'endDate',
+      title: 'this is title',
+      des: `If you just want to write the date and time without the text,\ndon't worry !\nYou can write a des props just by emptying it.\nAn example is shown below.`,
+    },
+    {
+      startDate: 'startDate',
+      endDate: 'endDate',
+      title: 'this is title',
+    },
     {
       startDate: 'startDate',
       endDate: 'endDate',
@@ -76,7 +97,10 @@ const Wrap = styled.div<{
   }
 `;
 
-const ChildWrap = styled.div`
+const ChildWrap = styled.div<{
+  theme?: 'basic' | 'box' | 'vertical';
+}>`
   display: flex;
-  flex-direction: column;
+  flex-direction: ${({ theme }) => (theme === 'vertical' ? 'row' : 'column')};
+  flex-wrap: wrap;
 `;

--- a/app/src/lib/components/Experience/Experience.tsx
+++ b/app/src/lib/components/Experience/Experience.tsx
@@ -102,5 +102,6 @@ const ChildWrap = styled.div<{
 }>`
   display: flex;
   flex-direction: ${({ theme }) => (theme === 'vertical' ? 'row' : 'column')};
-  flex-wrap: wrap;
+  flex-wrap: ${({ theme }) => (theme === 'vertical' ? 'wrap' : 'nowrap')};
+  white-space: pre-wrap;
 `;

--- a/app/src/lib/components/Experience/History/Basic.tsx
+++ b/app/src/lib/components/Experience/History/Basic.tsx
@@ -34,7 +34,6 @@ const Wrap = styled.div`
   flex-wrap: wrap;
   padding: 2.2em 2em 3.2em 2em;
   border-bottom: 0.2px solid #b4b4b4a2;
-  white-space: pre-wrap;
   .date {
     flex-grow: 1;
     text-align: center;
@@ -58,7 +57,7 @@ const Wrap = styled.div`
     flex-grow: 2;
     width: 30%;
     text-align: center;
-    @media screen and (max-width: 500px) {
+    @media screen and (max-width: 800px) {
       width: 100%;
     }
   }

--- a/app/src/lib/components/Experience/History/Basic.tsx
+++ b/app/src/lib/components/Experience/History/Basic.tsx
@@ -32,9 +32,10 @@ const Wrap = styled.div`
   justify-content: space-around;
   align-items: center;
   flex-wrap: wrap;
-  padding: 2.2em 2em 3.2em 2em;
+  /* padding: 2.2em 2em 3.2em 2em; */
   border-bottom: 0.2px solid #b4b4b4a2;
   .date {
+    padding: 2em;
     flex-grow: 1;
     text-align: center;
     .start-date {
@@ -54,6 +55,7 @@ const Wrap = styled.div`
     text-align: center;
   }
   .des {
+    padding: 2em;
     flex-grow: 2;
     width: 30%;
     text-align: center;

--- a/app/src/lib/components/Experience/History/Basic.tsx
+++ b/app/src/lib/components/Experience/History/Basic.tsx
@@ -14,13 +14,11 @@ const Basic = (props: Props) => {
   return (
     <div>
       <Wrap>
-        <div className="intro">
-          <div className="date">
-            <span className="start-date">{startDate}</span>
-            <span className="end-date">{endDate}</span>
-          </div>
-          <span className="child-title">{title}</span>
+        <div className="date">
+          <span className="start-date">{startDate}</span>
+          <span className="end-date">{endDate}</span>
         </div>
+        <span className="child-title">{title}</span>
         <span className="des">{des}</span>
       </Wrap>
     </div>
@@ -32,35 +30,36 @@ const Wrap = styled.div`
   margin: 0 auto;
   display: flex;
   justify-content: space-around;
+  align-items: center;
+  flex-wrap: wrap;
   padding: 2.2em 2em 3.2em 2em;
   border-bottom: 0.2px solid #b4b4b4a2;
   white-space: pre-wrap;
-  .intro {
-    min-width: 42%;
-    display: flex;
-    justify-content: space-around;
-    .date {
-      display: flex;
-      justify-content: space-between;
-      .start-date {
-        ::after {
-          content: '-';
-          margin: 0px 7px;
-        }
-      }
-      .end-date {
-        margin-left: 5px;
+  .date {
+    flex-grow: 1;
+    text-align: center;
+    .start-date {
+      ::after {
+        content: '-';
+        margin: 0px 7px;
       }
     }
-    .child-title {
-      width: 58%;
-      font-size: 22px;
-      font-weight: 600;
-      text-align: center;
+    .end-date {
+      margin-left: 5px;
     }
   }
-  .des {
-    width: 50%;
+  .child-title {
+    flex-grow: 1;
+    font-size: 22px;
+    font-weight: 600;
     text-align: center;
+  }
+  .des {
+    flex-grow: 2;
+    width: 30%;
+    text-align: center;
+    @media screen and (max-width: 500px) {
+      width: 100%;
+    }
   }
 `;

--- a/app/src/lib/components/Experience/History/Box.tsx
+++ b/app/src/lib/components/Experience/History/Box.tsx
@@ -14,13 +14,11 @@ const Box = (props: Props) => {
   return (
     <div>
       <Wrap>
-        <div className="intro">
-          <div className="date">
-            <span className="start-date">{startDate}</span>
-            <span className="end-date">{endDate}</span>
-          </div>
-          <span className="child-title">{title}</span>
+        <div className="date">
+          <span className="start-date">{startDate}</span>
+          <span className="end-date">{endDate}</span>
         </div>
+        <span className="child-title">{title}</span>
         <span className="des">{des}</span>
       </Wrap>
     </div>
@@ -29,41 +27,44 @@ const Box = (props: Props) => {
 export default Box;
 
 const Wrap = styled.div`
-  margin: 0 auto;
+  margin: 10px;
   display: flex;
   justify-content: space-around;
-  padding: 2.2em 2em 3.2em 2em;
+  align-items: center;
+  flex-wrap: wrap;
   box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.14);
   border-radius: 5px;
-  margin: 10px;
-  white-space: pre-wrap;
-  .intro {
-    min-width: 42%;
-    display: flex;
-    justify-content: space-around;
-    .date {
-      display: flex;
-      justify-content: space-between;
-      .start-date {
-        ::after {
-          content: '-';
-          margin: 0px 7px;
-        }
-      }
-      .end-date {
-        margin-left: 5px;
+  .date {
+    padding: 2em;
+    flex-grow: 1;
+    text-align: center;
+    .start-date {
+      ::after {
+        content: '-';
+        margin: 0px 7px;
       }
     }
-    .child-title {
-      width: 58%;
-      font-size: 22px;
-      font-weight: 600;
-      text-align: center;
-      border-right: 1px solid #b4b4b4a2;
+    .end-date {
+      margin-left: 5px;
+    }
+  }
+  .child-title {
+    flex-grow: 1;
+    font-size: 22px;
+    font-weight: 600;
+    text-align: center;
+    border-right: 1px solid #b4b4b4a2;
+    @media screen and (max-width: 800px) {
+      border: none;
     }
   }
   .des {
-    width: 50%;
+    padding: 2em;
+    flex-grow: 2;
+    width: 30%;
     text-align: center;
+    @media screen and (max-width: 800px) {
+      width: 100%;
+    }
   }
 `;

--- a/app/src/lib/components/Experience/History/Vertical.tsx
+++ b/app/src/lib/components/Experience/History/Vertical.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import styled, { css } from 'styled-components';
+
+interface Props {
+  startDate?: string;
+  endDate?: string;
+  title?: string;
+  des?: string;
+  titleColor?: string;
+  shape?: 'square' | 'round-square';
+}
+
+const Vertical = (props: Props) => {
+  const { startDate, endDate, title, des, shape, titleColor } = props;
+
+  return (
+    <Wrap shape={shape} titleColor={titleColor}>
+      <div className="intro">
+        <div className="date">
+          <span className="start-date">{startDate}</span>
+          <span className="end-date">{endDate}</span>
+        </div>
+        <div className="child-title">{title}</div>
+      </div>
+      <span className="des">{des}</span>
+    </Wrap>
+  );
+};
+
+export default Vertical;
+
+Vertical.defaultProps = {
+  shape: 'square',
+  titleColor: 'black',
+};
+
+const Wrap = styled.div<{
+  shape?: 'square' | 'round-square';
+  titleColor?: string;
+}>`
+  width: 23%;
+  padding: 10px 2em 1.2em 2em;
+  margin: 1em auto;
+  border: 1px solid #b4b4b4a2;
+  box-shadow: 0px 4px 10px 1px rgba(0, 0, 0, 0.04);
+  ${({ shape }) => {
+    switch (shape) {
+      case 'square':
+        return css`
+          border-radius: 0px;
+        `;
+      case 'round-square':
+        return css`
+          border-radius: 10px;
+        `;
+    }
+  }}
+  text-align: center;
+  .intro {
+    margin: 10px;
+    .date {
+      margin: 15px 0px 10px 0px;
+      font-size: 13px;
+      .start-date {
+        ::after {
+          content: '-';
+          margin: 0px 7px;
+        }
+      }
+      .end-date {
+        margin-left: 5px;
+      }
+    }
+    .child-title {
+      color: ${({ titleColor }) => titleColor ?? 'black'};
+      font-size: 25px;
+      font-weight: 600;
+      padding: 7px;
+      border-bottom: 1px solid #b4b4b4a2;
+    }
+  }
+`;

--- a/app/src/lib/components/Experience/History/Vertical.tsx
+++ b/app/src/lib/components/Experience/History/Vertical.tsx
@@ -38,7 +38,7 @@ const Wrap = styled.div<{
   shape?: 'square' | 'round-square';
   titleColor?: string;
 }>`
-  width: 23%;
+  width: 25em;
   padding: 10px 2em 1.2em 2em;
   margin: 1em auto;
   border: 1px solid #b4b4b4a2;

--- a/app/src/lib/components/Experience/History/index.tsx
+++ b/app/src/lib/components/Experience/History/index.tsx
@@ -1,12 +1,17 @@
 import Basic from './Basic';
 import Box from './Box';
+import Vertical from './Vertical';
 
 interface Props {
   startDate?: string;
   endDate?: string;
   title?: string;
   des?: string;
-  theme?: 'basic' | 'box';
+  theme?: 'basic' | 'box' | 'vertical';
+  verticalOption?: {
+    titleColor?: string;
+    shape?: 'square' | 'round-square';
+  };
 }
 
 const History = (props: Props) => {
@@ -17,6 +22,8 @@ const History = (props: Props) => {
       return <Basic {...props} />;
     case 'box':
       return <Box {...props} />;
+    case 'vertical':
+      return <Vertical {...props} />;
     default:
       return <Basic {...props} />;
   }


### PR DESCRIPTION
## Basic component

- Default
<img width="877" alt="image" src="https://user-images.githubusercontent.com/83394348/179341933-ffb0f2c9-bcb2-445c-bd82-beaeb4936cbd.png">

- max-width 800px
<img width="383" alt="image" src="https://user-images.githubusercontent.com/83394348/179341953-b71bd75b-a59d-4bfc-ad98-6ce2d00309b4.png">

- max-width 400px
<img width="181" alt="image" src="https://user-images.githubusercontent.com/83394348/179341991-eaae9f06-50c8-4222-80d0-a18286bb8def.png">


## Box component

- Default
<img width="917" alt="image" src="https://user-images.githubusercontent.com/83394348/179342013-20581ab0-3058-425c-aff5-878cc9c0985c.png">

- max-width 800px
<img width="364" alt="image" src="https://user-images.githubusercontent.com/83394348/179342037-b76d4c62-8f13-4b97-abab-b37e4c82f9a9.png">

- max-width 400px
<img width="184" alt="image" src="https://user-images.githubusercontent.com/83394348/179342018-0b96c92b-7ddc-48bd-8ce5-9079f0132598.png">


## Vertical component

- Default
![image](https://user-images.githubusercontent.com/83394348/179342299-5716ffb7-0aa0-4dc2-ae0a-5b4b086adfa3.png)

- max-width 800px
<img width="570" alt="image" src="https://user-images.githubusercontent.com/83394348/179342385-3efc53a4-6246-4c9c-9d89-40c210ca6cfb.png">

- max-width 400px
<img width="232" alt="image" src="https://user-images.githubusercontent.com/83394348/179342434-3dedabb3-e4ab-4464-b968-31589795e91d.png">
