### PR TITLE
[Chore] change masonry/image components to responsive web (#28)

### DIFF
--- a/app/src/lib/components/Masonry/Image.tsx
+++ b/app/src/lib/components/Masonry/Image.tsx
@@ -31,7 +31,7 @@ export default Image;
 Image.defaultProps = {
   subhead: 'Write your subhead',
   head: 'script your head',
-  redirectURL: '/'
+  redirectURL: '/',
 };
 
 const Wrap = styled.div`
@@ -63,10 +63,16 @@ const Items = styled.div`
     p {
       margin: 5px 0px 2px 1px;
       font-size: 14px;
+      @media screen and (max-width: 800px) {
+        font-size: 1.5vw;
+      }
     }
     span {
       font-size: 22px;
       font-weight: 800;
+      @media screen and (max-width: 800px) {
+        font-size: 1.5vw;
+      }
     }
     color: black;
     margin-bottom: 10px;

--- a/app/src/lib/components/Masonry/Masonry.tsx
+++ b/app/src/lib/components/Masonry/Masonry.tsx
@@ -24,4 +24,8 @@ const Wrap = styled.div<{
   padding: ${({ padding }) => padding ?? '2em 4em'};
   column-count: ${({ column }) => column ?? 4};
   column-gap: 1.5em;
+  @media screen and (max-width: 500px) {
+    padding: 1em 2em;
+    column-count: 2;
+  }
 `;


### PR DESCRIPTION
- default
<img width="918" alt="image" src="https://user-images.githubusercontent.com/83394348/179343516-e8038f62-a736-4bfb-8385-f7113b41a8e0.png">


- max-width: 500px
<img width="284" alt="image" src="https://user-images.githubusercontent.com/83394348/179343547-0ad8b725-1725-499f-807d-f13dbe941229.png">
