### PR TITLE
[Update] set column count values based on number of child elements (#62)

### DIFF
--- a/app/src/lib/components/Masonry/Masonry.tsx
+++ b/app/src/lib/components/Masonry/Masonry.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Children, useEffect } from 'react';
 import styled from 'styled-components';
 
 interface Props {
@@ -8,6 +8,12 @@ interface Props {
 }
 
 const Masonry = ({ children, padding, column }: Props) => {
+  const count = Children.count(children);
+
+  if (count <= 6) column = 3;
+  if (count <= 4) column = 2;
+  if (count <= 2) column = 1;
+
   return (
     <Wrap padding={padding} column={column}>
       {children}

--- a/app/src/lib/components/Masonry/Masonry.tsx
+++ b/app/src/lib/components/Masonry/Masonry.tsx
@@ -1,4 +1,4 @@
-import React, { Children, useEffect } from 'react';
+import React, { Children } from 'react';
 import styled from 'styled-components';
 
 interface Props {


### PR DESCRIPTION
## Masonry component 수정

하위요소 개수가 6개 이하일때 : column 수 3개
하위요소 개수가 4개 이하일때 : column 수 2개
하위요소 개수가 2개 이하일때 : column 수 1개

로 설정하였습니다~~