### PR TITLE
[Refactor] remove HardCode andd change already made Types #61

### DIFF
--- a/app/src/lib/components/TechStack/TechStacks/ProgressBar.tsx
+++ b/app/src/lib/components/TechStack/TechStacks/ProgressBar.tsx
@@ -1,6 +1,6 @@
 import styled, { keyframes } from 'styled-components';
 
-interface ProgressBarType {
+export interface ProgressBarType {
   rate?: string;
   colorFrom?: string;
   colorTo?: string;

--- a/app/src/lib/components/TechStack/TechStacks/TechStack.tsx
+++ b/app/src/lib/components/TechStack/TechStacks/TechStack.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
 import styled, { css } from 'styled-components';
 import TechStackName from './TechStackName';
-import ProgressBarContainer from './ProgressBar';
+import ProgressBarContainer, { ProgressBarType } from './ProgressBar';
+import { TechStackNameType } from './TechStackName';
 
 interface TechStackType {
-  nameOption: { name?: string; size?: string; iconColor?: string };
-  progressBarOption: { rate?: string; colorTo?: string; colorFrom?: string };
+  nameOption: TechStackNameType;
+  progressBarOption: ProgressBarType;
   gap?: 'narrower' | 'narrow' | 'normal' | 'wide' | 'wider';
 }
 

--- a/app/src/lib/components/TechStack/TechStacks/TechStackName.tsx
+++ b/app/src/lib/components/TechStack/TechStacks/TechStackName.tsx
@@ -3,7 +3,7 @@ import styled, { css } from 'styled-components';
 import { Icon } from '@iconify/react';
 import { clearConfigCache } from 'prettier';
 
-interface TechStackNameType {
+export interface TechStackNameType {
   name?: string;
   iconColor?: string;
   fontSize?: string;


### PR DESCRIPTION
* Remove HardCode andd change already made Types #61

## 설명
* 원래는 TechStackList 컴포넌트에 size 프롭스가 동작을 안하는 문제였으나, size 프롭스가 아닌 fontSize & logoSize를 프롭스로 던지는게 정상적임. (@woorim960 이 타입을 잘못 선언해버린 미스테이크)
* 기존 프롭스의 타입이 size로 되어있던 이름을 logoSize와 fontSize로 변경하였음.
* 추가로 타입이 각 컴포넌트 별 하드코딩으로 정의되어있는 것을 한 곳에서 import로 불러오도록 조정하였음.