### PR TITLE
[Update] reinforce carousel component (#142)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -65,10 +65,17 @@ function App() {
         <Image src="https://picsum.photos/500/600/?random" />
       </Masonry>
 
-      <Carousel>
-        <Item title="1" />
-        <Item title="2" />
-        <Item title="3" />
+      <Carousel slideToShow={6}>
+        <Card>0</Card>
+        <Card>1</Card>
+        <Card>2</Card>
+        <Card>3</Card>
+        <Card>4</Card>
+        <Card>5</Card>
+        <Card>6</Card>
+        <Card>7</Card>
+        <Card>8</Card>
+        <Card>9</Card>
       </Carousel>
       <Contact />
     </div>

--- a/src/lib/common/hooks/index.ts
+++ b/src/lib/common/hooks/index.ts
@@ -1,0 +1,2 @@
+export { default as useInteractiveMouseMove } from './useInteractiveMouseMove';
+export { default as useInterval } from './useInterval';

--- a/src/lib/common/hooks/useInterval.tsx
+++ b/src/lib/common/hooks/useInterval.tsx
@@ -1,0 +1,24 @@
+import { useEffect, useRef } from 'react';
+
+const useInterval = (callback: Function, delay: number, deps?: any[]) => {
+  const autoPlayRef = useRef<any>(null);
+
+  function resetTimeout() {
+    if (autoPlayRef.current) {
+      clearTimeout(autoPlayRef.current);
+    }
+  }
+  useEffect(() => {
+    resetTimeout();
+
+    autoPlayRef.current = setTimeout(() => {
+      callback();
+    }, delay);
+
+    return () => {
+      resetTimeout();
+    };
+  }, deps);
+};
+
+export default useInterval;

--- a/src/lib/components/Carousel/Carousel.tsx
+++ b/src/lib/components/Carousel/Carousel.tsx
@@ -69,7 +69,7 @@ const Carousel = ({
           </div>
         </Player>
       )}
-      <Container len={itemLength} transition={transitionTime} showIndex={showIndex}>
+      <Container len={itemLength} transition={transitionTime} showIndex={showIndex} slideToShow={slideToShow}>
         <div className="carousel-wrapper">
           <div className="carousel-container">
             {itemList.map((child, index) => {

--- a/src/lib/components/Carousel/hooks.tsx
+++ b/src/lib/components/Carousel/hooks.tsx
@@ -1,26 +1,6 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { useInterval } from '../../common/hooks';
 import { useCarouselPropsType } from '../../common/types/ComponentTypes/CarouselType';
-
-const useInterval = (callback: Function, delay: number, deps?: any[]) => {
-  const autoPlayRef = useRef<any>(null);
-
-  function resetTimeout() {
-    if (autoPlayRef.current) {
-      clearTimeout(autoPlayRef.current);
-    }
-  }
-  useEffect(() => {
-    resetTimeout();
-
-    autoPlayRef.current = setTimeout(() => {
-      callback();
-    }, delay);
-
-    return () => {
-      resetTimeout();
-    };
-  }, deps);
-};
 
 const useCarousel = ({
   children,
@@ -29,94 +9,61 @@ const useCarousel = ({
   autoplaySpeed = 3000,
   isAutoplay = false,
 }: useCarouselPropsType) => {
-  const childrenLength = React.Children.toArray(children).length;
   const [itemList, setItemList] = useState<any[]>([]);
   const [coordinateX, setCoordinateX] = useState(0);
   const [autoPlayStatus, setAutoPlayStatus] = useState<boolean>(isAutoplay);
   const [transitionTime, setTransitionTime] = useState(0);
   const [disable, setDisable] = useState(false);
-  const itemLength = useMemo(() => itemList.length, [itemList]);
   const [forwardItemLength, setForwardItemLength] = useState(0);
   const [showIndex, setShowIndex] = useState(0);
 
-  const showPrev = () => {
-    if (disable) return;
+  const childrenLength = React.Children.toArray(children).length;
+  const itemLength = useMemo(() => itemList.length, [itemList]);
+
+  const startTransition = () => {
     setDisable(true);
     setTransitionTime(transition);
-    setShowIndex(showIndex - slideToShow);
+  };
 
-    setTimeout(() => {
-      setTransitionTime(0);
-      setItemList((prev) => {
-        const temp = [...prev];
-        const result = [];
-        setShowIndex(showIndex + childrenLength / slideToShow - 1);
-
-        if (childrenLength / slideToShow < slideToShow) {
-          const origin = temp.splice(slideToShow, childrenLength);
-          for (let i = 0; i < slideToShow; i++) {
-            result.unshift(origin.pop());
-          }
-          origin.unshift(...result);
-          const f = origin.slice(0, slideToShow);
-          const b = origin.slice(-slideToShow);
-          origin.push(...f);
-          origin.unshift(...b);
-          return origin;
-        } else {
-          for (let i = 0; i < slideToShow; i++) {
-            result.unshift(temp.pop());
-          }
-          temp.unshift(...result);
-          return temp;
-        }
-      });
-    }, transition);
-
+  const endTransition = () => {
     setTimeout(() => {
       setDisable(false);
       setShowIndex(forwardItemLength);
     }, transition);
   };
 
+  const showPrev = () => {
+    if (disable) return;
+    startTransition();
+    setShowIndex(showIndex - slideToShow);
+
+    setTimeout(() => {
+      setTransitionTime(0);
+      setItemList((prev) => {
+        const { list: result, index } = setPreviousItem({ prevList: prev, showIndex, slideToShow, childrenLength });
+        setShowIndex(index);
+        return result;
+      });
+    }, transition);
+
+    endTransition();
+  };
+
   const showNext = () => {
     if (disable) return;
-    setDisable(true);
-    setTransitionTime(transition);
+    startTransition();
     setShowIndex(showIndex + slideToShow);
 
     setTimeout(() => {
       setTransitionTime(0);
       setItemList((prev) => {
-        const temp = [...prev];
-        const result = [];
-        setShowIndex(showIndex - childrenLength / slideToShow + 1);
-
-        if (childrenLength / slideToShow < slideToShow) {
-          const origin = temp.splice(slideToShow, childrenLength);
-          for (let i = 0; i < slideToShow; i++) {
-            result.push(origin.shift());
-          }
-          origin.push(...result);
-          const f = origin.slice(0, slideToShow);
-          const b = origin.slice(-slideToShow);
-          origin.push(...f);
-          origin.unshift(...b);
-          return origin;
-        } else {
-          for (let i = 0; i < slideToShow; i++) {
-            result.push(temp.shift());
-          }
-          temp.push(...result);
-          return temp;
-        }
+        const { list: result, index } = setNextItem({ prevList: prev, showIndex, slideToShow, childrenLength });
+        setShowIndex(index);
+        return result;
       });
     }, transition);
 
-    setTimeout(() => {
-      setDisable(false);
-      setShowIndex(forwardItemLength);
-    }, transition);
+    endTransition();
   };
 
   const onTouchStart = (e: React.TouchEvent) => {
@@ -157,35 +104,15 @@ const useCarousel = ({
   );
 
   useEffect(() => {
-    const list = React.Children.toArray(children);
-    const showItems = list.slice(0, slideToShow);
-    const restItems = list.slice(slideToShow);
+    const { list, index, length } = init({ children, slideToShow });
 
-    const backwardItems = restItems.slice(0, Math.floor(restItems.length / 2));
-
-    const forwardItems = restItems.slice(Math.floor(restItems.length / 2));
-    const result = [...forwardItems, ...showItems, ...backwardItems];
-
-    if (childrenLength / slideToShow < slideToShow) {
-      const f = result.slice(0, slideToShow);
-      const b = result.slice(-slideToShow);
-      result.push(...f);
-      result.unshift(...b);
-      setShowIndex(forwardItems.length + slideToShow);
-      setForwardItemLength(forwardItems.length + slideToShow);
-    } else {
-      setShowIndex(forwardItems.length);
-      setForwardItemLength(forwardItems.length);
-    }
-
-    setItemList(result);
+    setShowIndex(index);
+    setForwardItemLength(length);
+    setItemList(list);
   }, []);
 
   useEffect(() => {
     setTransitionTime(0);
-    setTimeout(() => {
-      setTransitionTime(transition);
-    }, transition);
   }, []);
 
   return {
@@ -207,3 +134,103 @@ const useCarousel = ({
 };
 
 export { useInterval, useCarousel };
+
+const init = ({ children, slideToShow }: { children: React.ReactNode; slideToShow: number }) => {
+  const list = React.Children.toArray(children);
+  const showItems = list.slice(0, slideToShow);
+  const restItems = list.slice(slideToShow);
+
+  const backwardItems = restItems.slice(0, Math.floor(restItems.length / 2));
+
+  const forwardItems = restItems.slice(Math.floor(restItems.length / 2));
+  const result = [...forwardItems, ...showItems, ...backwardItems];
+
+  let showIndex = 0;
+  let forwardItemLength = 0;
+
+  if (Math.floor(list.length / slideToShow) <= slideToShow) {
+    const f = result.slice(0, slideToShow);
+    const b = result.slice(-slideToShow);
+    result.push(...f);
+    result.unshift(...b);
+    showIndex = forwardItems.length + slideToShow;
+    forwardItemLength = forwardItems.length + slideToShow;
+  } else {
+    showIndex = forwardItems.length;
+    forwardItemLength = forwardItems.length;
+  }
+
+  return { list: result, index: showIndex, length: forwardItemLength };
+};
+
+const setNextItem = ({
+  prevList,
+  childrenLength,
+  slideToShow,
+  showIndex,
+}: {
+  prevList: any[];
+  childrenLength: number;
+  slideToShow: number;
+  showIndex: number;
+}) => {
+  const list =
+    Math.floor(childrenLength / slideToShow) <= slideToShow
+      ? [...prevList].splice(slideToShow, childrenLength)
+      : [...prevList];
+  const result = [];
+  const index = showIndex - childrenLength / slideToShow + 1;
+
+  if (Math.floor(childrenLength / slideToShow) <= slideToShow) {
+    for (let i = 0; i < slideToShow; i++) {
+      result.push(list.shift());
+    }
+    list.push(...result);
+    const f = list.slice(0, slideToShow);
+    const b = list.slice(-slideToShow);
+    list.push(...f);
+    list.unshift(...b);
+  } else {
+    for (let i = 0; i < slideToShow; i++) {
+      result.push(list.shift());
+    }
+    list.push(...result);
+  }
+  return { list, index };
+};
+
+const setPreviousItem = ({
+  prevList,
+  childrenLength,
+  slideToShow,
+  showIndex,
+}: {
+  prevList: any[];
+  childrenLength: number;
+  slideToShow: number;
+  showIndex: number;
+}) => {
+  const list =
+    Math.floor(childrenLength / slideToShow) <= slideToShow
+      ? [...prevList].splice(slideToShow, childrenLength)
+      : [...prevList];
+  const result = [];
+  const index = showIndex + childrenLength / slideToShow - 1;
+
+  if (Math.floor(childrenLength / slideToShow) <= slideToShow) {
+    for (let i = 0; i < slideToShow; i++) {
+      result.unshift(list.pop());
+    }
+    list.unshift(...result);
+    const f = list.slice(0, slideToShow);
+    const b = list.slice(-slideToShow);
+    list.push(...f);
+    list.unshift(...b);
+  } else {
+    for (let i = 0; i < slideToShow; i++) {
+      result.unshift(list.pop());
+    }
+    list.unshift(...result);
+  }
+  return { list, index };
+};

--- a/src/lib/components/Carousel/hooks.tsx
+++ b/src/lib/components/Carousel/hooks.tsx
@@ -186,10 +186,10 @@ const setNextItem = ({
       result.push(list.shift());
     }
     list.push(...result);
-    const f = list.slice(0, slideToShow);
-    const b = list.slice(-slideToShow);
-    list.push(...f);
-    list.unshift(...b);
+    const forward = list.slice(0, slideToShow);
+    const backward = list.slice(-slideToShow);
+    list.push(...forward);
+    list.unshift(...backward);
   } else {
     for (let i = 0; i < slideToShow; i++) {
       result.push(list.shift());
@@ -222,10 +222,10 @@ const setPreviousItem = ({
       result.unshift(list.pop());
     }
     list.unshift(...result);
-    const f = list.slice(0, slideToShow);
-    const b = list.slice(-slideToShow);
-    list.push(...f);
-    list.unshift(...b);
+    const forward = list.slice(0, slideToShow);
+    const backward = list.slice(-slideToShow);
+    list.push(...forward);
+    list.unshift(...backward);
   } else {
     for (let i = 0; i < slideToShow; i++) {
       result.unshift(list.pop());

--- a/src/lib/components/Carousel/style.tsx
+++ b/src/lib/components/Carousel/style.tsx
@@ -66,6 +66,7 @@ export const Container = styled.div<{
   len: number;
   transition: number;
   showIndex: number;
+  slideToShow: number;
 }>`
   overflow: hidden;
   .carousel-wrapper {
@@ -74,11 +75,11 @@ export const Container = styled.div<{
   .carousel-container {
     display: flex;
     position: relative;
-    ${({ transition, len, showIndex }) => {
+    ${({ transition, len, showIndex, slideToShow }) => {
       return css`
         transition: ${transition / 1000}s;
         width: calc(${len} * 100%);
-        transform: translateX(${(-showIndex * 100) / len}%);
+        transform: translateX(${(-showIndex * 100) / len / slideToShow}%);
       `;
     }}
   }

--- a/src/lib/components/Carousel/style.tsx
+++ b/src/lib/components/Carousel/style.tsx
@@ -47,6 +47,13 @@ export const Wrapper = styled.div<{
         bottom: ${bottom};
         transform: translateY(${translateY});
         z-index: 3;
+        transition: 0.3s scale;
+        &:hover {
+          scale: 1.1;
+        }
+        &:active {
+          scale: 1;
+        }
         cursor: pointer;
       }
       #next-button {
@@ -131,4 +138,13 @@ export const Player = styled.div<{
         `;
     }
   }}
+  .icon-wrapper {
+    &:hover {
+      transform: scale(1.1);
+    }
+    &:active {
+      transform: scale(1);
+    }
+    transition: 0.3s;
+  }
 `;


### PR DESCRIPTION
## 작업내용
- 캐러셀 children render 방식 수정
- 버튼 아이콘에 animation 적용 (hover시 scale 증가, active시 scale 원복) 
- 로직 분리
- useInterval hook 위치 변경
- Carousel 예제 수정 (기존 예제는 이미지가 있어서 테스트하기 불편했기에 Card 컴포넌트로 바꿨습니다.)


## 캐러셀 children render 방식 수정

기존 작업된 캐러셀은 최초 생성될때 children의 3배수 만큼의 DOM이 render되었습니다.
이는 매우 비효율적인 방식이라 캐러셀이 생성될때의 로직을 수정해서 children의 개수만큼만 render 되도록 수정했습니다.

하지만 children의 길이와 slideToShow의 비율에 따라서 transition이 발생했을때, 순간적으로 빈 공간이 생기는 이슈가있어,
그런 경우에는 불가피하게 DOM을 추가로 rendering하도록 로직을 구현했습니다.

이 방식은 React Slick이나 Swiper같은 저명한  Carousel 라이브러리에서 이미 사용하는 방식이기 때문에,
현재로서는 가장 적절한 방식이라고 생각됩니다.
 