### PR TITLE
fix: remove onMouseDown and onMouseUp event (#210)

### DIFF
--- a/src/lib/components/Carousel/hooks.tsx
+++ b/src/lib/components/Carousel/hooks.tsx
@@ -119,8 +119,8 @@ const useCarousel = ({
     itemLength,
     transitionTime,
     listeners: {
-      onMouseDown,
-      onMouseUp,
+      // onMouseDown,
+      // onMouseUp,
       onTouchEnd,
       onTouchStart,
       showNext,


### PR DESCRIPTION
## Description 
> onMouseDown 이벤트가 href의 상위에 걸려있어서 링크로의 리다이렉션이 동작하지 않음.

해당 버그를 수정하려면 a태그에 href가 걸려있는 모든 컴포넌트에
onMouseDown 이벤트를 통한 리다이렉션 기능을 추가해야함.

이로 인해 해결책을 다른 찾기 전까지 일단 마우스 드래그 동작을 통한 캐러셀 넘기기 기능을 제거

## Issue Number
210

